### PR TITLE
#41 Make target directory and file names for report files configurable

### DIFF
--- a/coverage/src/main/java/com/github/lizardev/xquery/saxon/coverage/report/FileReportPrinter.java
+++ b/coverage/src/main/java/com/github/lizardev/xquery/saxon/coverage/report/FileReportPrinter.java
@@ -19,7 +19,7 @@ public class FileReportPrinter implements ReportPrinter {
     private HtmlModuleReportGenerator moduleReportGenerator = new HtmlModuleReportGenerator();
     private HtmlModuleReportIndexGenerator moduleReportIndexGenerator = new HtmlModuleReportIndexGenerator();
     private StaticResourceTransferor resourceTransferor = new StaticResourceTransferor();
-
+	
     @Override public void print(Report report) {
         deleteDir(baseDir);
         List<ModuleReportReference> moduleReportReferences = newArrayList();
@@ -33,7 +33,39 @@ public class FileReportPrinter implements ReportPrinter {
         resourceTransferor.copyResources(baseDir);
     }
 
+	/**
+	  * Returns the directory into which the report will be written.
+	  */
+	public File getReportDir() {
+		return baseDir;
+	}
+	
+	/**
+	  * The coverage report consists of many files that are stored in a directory.
+	  * This method can be called to override the default report directory.
+	  *
+	  * <b>Be aware that the directory will be deleted prior to report generation!</b>
+	  *
+	  * @see DEFAULT_REPORT_DIR
+	  */
+	public void setReportDir(File reportDir) {
+		baseDir = reportDir;
+	}
+	
     private File getHtmlModuleReportFile(ModuleReport moduleReport) {
-        return new File(baseDir, uriToFilename(moduleReport.getModuleUri().getUri()) + ".html");
+        return new File(baseDir, generateFilename(moduleReport));
     }
+	
+	/**
+	  * This is a template method for generating a report file name for a given 
+	  * XQuery module.
+	  * The default implementation calls uriToFilename and appends an .html suffix
+	  *
+	  * @param moduleReport the description of the XQuery module
+	  * @return non-null, valid file name ending in .html or .htm
+	  * @see com.github.lizardev.xquery.saxon.coverage.util.UriUtils#uriToFilename
+	  */
+	protected String generateFilename(ModuleReport moduleReport) {
+		return uriToFilename(moduleReport.getModuleUri().getUri()) + ".html";
+	}
 }

--- a/coverage/src/test/java/com/github/lizardev/xquery/saxon/coverage/report/FileReportPrinterTest.java
+++ b/coverage/src/test/java/com/github/lizardev/xquery/saxon/coverage/report/FileReportPrinterTest.java
@@ -1,0 +1,33 @@
+package com.github.lizardev.xquery.saxon.coverage.report;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+
+import com.github.lizardev.xquery.saxon.coverage.ModuleUri;
+import org.junit.Test;
+
+import static com.github.lizardev.xquery.saxon.coverage.util.UriUtils.uriToFilename;
+import static org.junit.Assert.assertEquals;
+
+public abstract class FileReportPrinterTest {
+
+	@Test
+	public void testDefaultGenerateFilename() throws Exception {
+		FileReportPrinter printer = new FileReportPrinter();
+		
+		URI uri = new URI("file://c/myfile.xq");
+		ModuleUri moduleUri = new ModuleUri(uri);
+		ModuleReport mr = new ModuleReport(moduleUri, new ArrayList<LineReport>());
+		assertEquals(uriToFilename(uri), printer.generateFilename(mr));
+	}
+
+	
+	@Test
+	public void testDefaultReportDir() throws Exception {
+		FileReportPrinter printer = new FileReportPrinter();
+		
+		assertEquals(new File(FileReportPrinter.DEFAULT_REPORT_DIR), printer.getReportDir());
+	}
+	
+}


### PR DESCRIPTION
Two enhancements to the FileReportPrinter:
* Make the report directory configurable by providing a setter
* Extract a template method that encapsulates the algorithm for generating file names for module reports so that a subclass can provide a different implementation