### PR TITLE
Fix problem with report writing when used with Gradle

### DIFF
--- a/coverage/src/main/java/com/github/lizardev/xquery/saxon/coverage/CoverageService.java
+++ b/coverage/src/main/java/com/github/lizardev/xquery/saxon/coverage/CoverageService.java
@@ -30,7 +30,6 @@ public class CoverageService {
 
     public void generateReport() {
         Report report = defaultCoverageInstructionEventHandler.getReport();
-        new StreamReportPrinter(System.err).print(report);
         new FileReportPrinter().print(report);
     }
 


### PR DESCRIPTION
Gradle handle writing to System.err as using Logger and this Logger
is not available in shutdown hook. So, dropping "console report" allow
to write HTML report.